### PR TITLE
fix: Raise minimum urllib3 package to 1.26.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ packages = [
 
 [tool.poetry.dependencies]
 python = ">=3.7"
-urllib3 = ">=1.22.0,<3"
+urllib3 = ">=1.26.0,<3"
 
 
 [tool.poetry.group.dev.dependencies]
@@ -59,7 +59,7 @@ expiringdict = ">=1.1.4"
 pyrfc3339 = ">=1.0"
 jsonpickle = ">1.4.1"
 semver = ">=2.7.9"
-urllib3 = ">=1.22.0"
+urllib3 = ">=1.26.0"
 jinja2 = "3.0.0"
 
 [tool.mypy]


### PR DESCRIPTION
Our usage of the `Retry` object from the `urllib3` package depends on a
signature that was introduced in v1.26.0.

Fixes #25
