### PR TITLE
ci: Ensure poetry version uses correct python version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,10 +64,11 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      - name: Install poetry
+        uses: abatilo/actions-poetry@7b6d33e44b4f08d7021a1dee3c044e9c253d6439
+
       - name: Install requirements
-        run: |
-          pipx install poetry
-          poetry install
+        run: poetry install
 
       - uses: ./.github/actions/build
       - uses: ./.github/actions/build-docs

--- a/.github/workflows/manual-publish-docs.yml
+++ b/.github/workflows/manual-publish-docs.yml
@@ -16,7 +16,7 @@ jobs:
           python-version: 3.8
 
       - name: Install poetry
-        run: pipx install poetry
+        uses: abatilo/actions-poetry@7b6d33e44b4f08d7021a1dee3c044e9c253d6439
 
       - uses: ./.github/actions/build-docs
 

--- a/.github/workflows/manual-publish.yml
+++ b/.github/workflows/manual-publish.yml
@@ -22,7 +22,7 @@ jobs:
           python-version: 3.8
 
       - name: Install poetry
-        run: pipx install poetry
+        uses: abatilo/actions-poetry@7b6d33e44b4f08d7021a1dee3c044e9c253d6439
 
       - uses: launchdarkly/gh-actions/actions/release-secrets@release-secrets-v1.0.0
         name: 'Get PyPI token'

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Install poetry
         if: ${{ steps.release.outputs.releases_created }}
-        run: pipx install poetry
+        uses: abatilo/actions-poetry@7b6d33e44b4f08d7021a1dee3c044e9c253d6439
 
       - uses: launchdarkly/gh-actions/actions/release-secrets@release-secrets-v1.0.0
         name: 'Get PyPI token'


### PR DESCRIPTION
`pipx install poetry` does not necessarily use the configured python
version specified in `actions/setup-python`. This separate GH action
helps ensure we are using the correct version consistently.
