### PR TITLE
fix: Fix SSE delay reset handling

### DIFF
--- a/ld_eventsource/sse_client.py
+++ b/ld_eventsource/sse_client.py
@@ -111,7 +111,7 @@ class SSEClient:
 
         self.__connection_client = connect.create_client(logger)
         self.__connection_result: Optional[ConnectionResult] = None
-        self.__retry_reset_baseline: float = 0
+        self._retry_reset_baseline: float = 0
         self.__disconnected_time: float = 0
 
         self.__closed = False
@@ -253,12 +253,12 @@ class SSEClient:
         # In those situations, we don't want to reset the retry delay strategy;
         # it should continue to double until the retry maximum, and then hold
         # steady (- jitter).
-        if self.__retry_delay_reset_threshold > 0 and self.__retry_reset_baseline != 0:
+        if self.__retry_delay_reset_threshold > 0 and self._retry_reset_baseline != 0:
             now = time.time()
-            connection_duration = now - self.__retry_reset_baseline
+            connection_duration = now - self._retry_reset_baseline
             if connection_duration >= self.__retry_delay_reset_threshold:
                 self.__current_retry_delay_strategy = self.__base_retry_delay_strategy
-                self.__retry_reset_baseline = now
+                self._retry_reset_baseline = now
         self.__next_retry_delay, self.__current_retry_delay_strategy = (
             self.__current_retry_delay_strategy.apply(self.__base_retry_delay)
         )
@@ -294,7 +294,7 @@ class SSEClient:
                 # If can_return_fault is false, it means the caller explicitly called start(), in
                 # which case there's no way to return a Fault so we just keep retrying transparently.
                 continue
-            self.__retry_reset_baseline = time.time()
+            self._retry_reset_baseline = time.time()
             self.__current_error_strategy = self.__base_error_strategy
             self.__interrupted = False
             return None

--- a/ld_eventsource/sse_client.py
+++ b/ld_eventsource/sse_client.py
@@ -111,7 +111,7 @@ class SSEClient:
 
         self.__connection_client = connect.create_client(logger)
         self.__connection_result: Optional[ConnectionResult] = None
-        self.__connected_time: float = 0
+        self.__retry_reset_baseline: float = 0
         self.__disconnected_time: float = 0
 
         self.__closed = False
@@ -248,10 +248,17 @@ class SSEClient:
         return self.__next_retry_delay
 
     def _compute_next_retry_delay(self):
-        if self.__retry_delay_reset_threshold > 0 and self.__connected_time != 0:
-            connection_duration = time.time() - self.__connected_time
+        # If the __retry_reset_baseline is 0, then we haven't successfully connected yet.
+        #
+        # In those situations, we don't want to reset the retry delay strategy;
+        # it should continue to double until the retry maximum, and then hold
+        # steady (- jitter).
+        if self.__retry_delay_reset_threshold > 0 and self.__retry_reset_baseline != 0:
+            now = time.time()
+            connection_duration = now - self.__retry_reset_baseline
             if connection_duration >= self.__retry_delay_reset_threshold:
                 self.__current_retry_delay_strategy = self.__base_retry_delay_strategy
+                self.__retry_reset_baseline = now
         self.__next_retry_delay, self.__current_retry_delay_strategy = (
             self.__current_retry_delay_strategy.apply(self.__base_retry_delay)
         )
@@ -287,7 +294,7 @@ class SSEClient:
                 # If can_return_fault is false, it means the caller explicitly called start(), in
                 # which case there's no way to return a Fault so we just keep retrying transparently.
                 continue
-            self.__connected_time = time.time()
+            self.__retry_reset_baseline = time.time()
             self.__current_error_strategy = self.__base_error_strategy
             self.__interrupted = False
             return None

--- a/ld_eventsource/testing/test_sse_client_retry.py
+++ b/ld_eventsource/testing/test_sse_client_retry.py
@@ -1,8 +1,9 @@
+from time import sleep
+
 from ld_eventsource import *
 from ld_eventsource.actions import *
 from ld_eventsource.config import *
 from ld_eventsource.testing.helpers import *
-from time import sleep
 
 
 def test_retry_during_initial_connect_succeeds():


### PR DESCRIPTION
The default retry policy has exponential backoff with jitter. This retry
strategy is reset after some maximum retry interval.

Previously, once this reset interval occurred, it would continue to
reset every future attempt, effectively disabling the exponential
backoff algorithm.

This should no longer be the case, as we now reset the baseline used for
determine when to reset the strategy each time it is replaced with the
base strategy.
