### PR TITLE
fix: replace deprecated "wrap_socket" function; Add use of SSLContext

### DIFF
--- a/ld_eventsource/testing/http_util.py
+++ b/ld_eventsource/testing/http_util.py
@@ -1,9 +1,9 @@
 import json
 import queue
 import socket
-import ssl
 import time
 from http.server import BaseHTTPRequestHandler, HTTPServer
+from ssl import SSLContext
 from threading import Thread
 
 
@@ -51,7 +51,7 @@ class MockServerWrapper(Thread):
         self.uri = '%s://localhost:%d' % ('https' if secure else 'http', port)
         self.server = HTTPServer(('localhost', port), MockServerRequestHandler)
         if secure:
-            self.server.socket = ssl.wrap_socket(
+            self.server.socket = SSLContext.wrap_socket(
                 self.server.socket,
                 certfile='./ld_eventsource/testing/selfsigned.pem',  # this is a pre-generated self-signed cert that is valid for 100 years
                 keyfile='./ld_eventsource/testing/selfsigned.key',


### PR DESCRIPTION
**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Related issues**
https://github.com/launchdarkly/python-eventsource/issues/41

**Describe the solution you've provided**
I changed the code to use SSLContext.

**Describe alternatives you've considered**
None

**Additional context**

![15094FCE-A547-447F-A0DA-F46008AF70D6_1_201_a](https://github.com/user-attachments/assets/d835307e-7383-4173-b5ff-1939dc95dae9)
