### PR TITLE
fix: Catch all response.shutdown exceptions

### DIFF
--- a/ld_eventsource/http.py
+++ b/ld_eventsource/http.py
@@ -91,7 +91,7 @@ class _HttpClientImpl:
         def close():
             try:
                 resp.shutdown()
-            except AttributeError:
+            except Exception:
                 pass
             resp.release_conn()
 


### PR DESCRIPTION
The response shutdown might trigger an exception for a number of
reasons from within the urllib3 library. Since this is a shutdown
procedure, and there isn't a way to recover at that point, we are going
to simply catch all possible exceptions and continue to shutdown as
gracefully as possible.
