### PR TITLE
fix: Close the connection client on SSEClient.close()

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,11 @@ An async implementation, `AsyncSSEClient`, is also available for use with `async
 pip install launchdarkly-eventsource[async]
 ```
 
+> [!CAUTION]
+> The async implementation (`AsyncSSEClient` and its associated `AsyncConnectStrategy` API) is experimental and should NOT be considered ready for production use. It may change or be removed without notice and is not subject to backwards compatibility guarantees.
+>
+> Pin to a specific minor version and review the changelog before upgrading.
+
 ## Supported Python versions
 
 This version of the package is compatible with Python 3.9 and higher.

--- a/ld_eventsource/async_client.py
+++ b/ld_eventsource/async_client.py
@@ -16,6 +16,12 @@ class AsyncSSEClient:
     """
     An async client for reading a Server-Sent Events stream.
 
+    .. caution::
+        This feature is experimental and should NOT be considered ready for production
+        use. It may change or be removed without notice and is not subject to backwards
+        compatibility guarantees. Pin to a specific minor version and review the changelog
+        before upgrading.
+
     This is an async/await implementation. The expected usage is to create an ``AsyncSSEClient``
     instance (either as an async context manager or directly), then read from it using the async
     iterator properties :attr:`events` or :attr:`all`.

--- a/ld_eventsource/config/async_connect_strategy.py
+++ b/ld_eventsource/config/async_connect_strategy.py
@@ -10,6 +10,12 @@ class AsyncConnectStrategy:
     """
     An abstraction for how :class:`.AsyncSSEClient` should obtain an input stream.
 
+    .. caution::
+        This feature is experimental and should NOT be considered ready for production
+        use. It may change or be removed without notice and is not subject to backwards
+        compatibility guarantees. Pin to a specific minor version and review the changelog
+        before upgrading.
+
     The default implementation is :meth:`http()`, which makes HTTP requests with ``aiohttp``.
     Or, if you want to consume an input stream from some other source, you can create your own
     subclass of :class:`AsyncConnectStrategy`.
@@ -58,6 +64,12 @@ class AsyncConnectionClient:
     """
     An object provided by :class:`.AsyncConnectStrategy` that is retained by a single
     :class:`.AsyncSSEClient` to perform all connection attempts by that instance.
+
+    .. caution::
+        This feature is experimental and should NOT be considered ready for production
+        use. It may change or be removed without notice and is not subject to backwards
+        compatibility guarantees. Pin to a specific minor version and review the changelog
+        before upgrading.
     """
 
     async def connect(self, last_event_id: Optional[str]) -> AsyncConnectionResult:
@@ -85,6 +97,12 @@ class AsyncConnectionClient:
 class AsyncConnectionResult:
     """
     The return type of :meth:`AsyncConnectionClient.connect()`.
+
+    .. caution::
+        This feature is experimental and should NOT be considered ready for production
+        use. It may change or be removed without notice and is not subject to backwards
+        compatibility guarantees. Pin to a specific minor version and review the changelog
+        before upgrading.
     """
 
     def __init__(

--- a/ld_eventsource/reader.py
+++ b/ld_eventsource/reader.py
@@ -66,7 +66,6 @@ class _SSEReader:
     def last_event_id(self):
         return self._last_event_id
 
-    @property
     def events_and_comments(self):
         event_type = ""
         event_data = None

--- a/ld_eventsource/sse_client.py
+++ b/ld_eventsource/sse_client.py
@@ -95,7 +95,7 @@ class SSEClient:
         if isinstance(connect, str):
             connect = ConnectStrategy.http(connect)
         elif not isinstance(connect, ConnectStrategy):
-            raise TypeError("request must be either a string or ConnectStrategy")
+            raise TypeError("connect must be either a string or ConnectStrategy")
 
         self.__base_retry_delay = initial_retry_delay
         self.__base_retry_delay_strategy = (
@@ -116,7 +116,7 @@ class SSEClient:
             logger.propagate = False
         self.__logger = logger
 
-        self.__connection_client = connect.create_client(logger)
+        self.__connection_client: ConnectionClient = connect.create_client(logger)
         self.__connection_result: Optional[ConnectionResult] = None
         self._retry_reset_baseline: float = 0
         self.__disconnected_time: float = 0
@@ -151,6 +151,7 @@ class SSEClient:
         """
         self.__closed = True
         self.interrupt()
+        self.__connection_client.close()
 
     def interrupt(self):
         """
@@ -181,6 +182,22 @@ class SSEClient:
         already active, so you do not need to call :meth:`start()` unless you want to verify that
         the stream is connected before trying to read events.
         """
+        return self._all_generator()
+
+    @property
+    def events(self) -> Iterable[Event]:
+        """
+        An iterable series of :class:`.Event` objects received from the stream.
+
+        Use :attr:`all` instead if you also want to know about other kinds of occurrences.
+
+        Iterating over this property automatically starts or restarts the stream if it is not
+        already active, so you do not need to call :meth:`start()` unless you want to verify that
+        the stream is connected before trying to read events.
+        """
+        return self._events_generator()
+
+    def _all_generator(self):
         while True:
             # Reading implies starting the stream if it isn't already started. We might also
             # be restarting since we could have been interrupted at any time.
@@ -194,11 +211,12 @@ class SSEClient:
             reader = _SSEReader(lines, self.__last_event_id, None)
             error: Optional[Exception] = None
             try:
-                for ec in reader.events_and_comments:
+                for ec in reader.events_and_comments():
+                    self.__last_event_id = reader.last_event_id
                     yield ec
                     if self.__interrupted:
                         break
-                # If we finished iterating all of reader.events_and_comments, it means the stream
+                # If we finished iterating all of reader.events_and_comments(), it means the stream
                 # was closed without an error.
                 self.__connection_result = None
             except Exception as e:
@@ -226,18 +244,8 @@ class SSEClient:
             yield Fault(error)
             continue  # try to connect again
 
-    @property
-    def events(self) -> Iterable[Event]:
-        """
-        An iterable series of :class:`.Event` objects received from the stream.
-
-        Use :attr:`all` instead if you also want to know about other kinds of occurrences.
-
-        Iterating over this property automatically starts or restarts the stream if it is not
-        already active, so you do not need to call :meth:`start()` unless you want to verify that
-        the stream is connected before trying to read events.
-        """
-        for item in self.all:
+    def _events_generator(self):
+        for item in self._all_generator():
             if isinstance(item, Event):
                 yield item
 

--- a/ld_eventsource/testing/test_reader.py
+++ b/ld_eventsource/testing/test_reader.py
@@ -55,7 +55,7 @@ class TestBufferedLineReader:
 
 class TestSSEReader:
     def expect_output(self, lines, expected):
-        output = list(_SSEReader(lines).events_and_comments)
+        output = list(_SSEReader(lines).events_and_comments())
         assert output == expected
 
     def test_parses_event_with_all_fields(self):
@@ -98,12 +98,12 @@ class TestSSEReader:
             got_retry = value
 
         lines = ["retry: 1000"]
-        list(_SSEReader(lines, None, store_retry).events_and_comments)
+        list(_SSEReader(lines, None, store_retry).events_and_comments())
         assert got_retry == 1000
 
     def test_ignores_retry_interval_if_no_callback_given(self):
         lines = ["retry: 1000"]
-        list(_SSEReader(lines, None, None).events_and_comments)
+        list(_SSEReader(lines, None, None).events_and_comments())
 
     def test_remembers_last_event_id(self):
         lines = [
@@ -124,5 +124,5 @@ class TestSSEReader:
             Event("message", "third", None, "b"),
             Event("message", "fourth", "", ""),
         ]
-        output = list(_SSEReader(lines, last_event_id="a").events_and_comments)
+        output = list(_SSEReader(lines, last_event_id="a").events_and_comments())
         assert output == expected

--- a/ld_eventsource/testing/test_sync_async_parity.py
+++ b/ld_eventsource/testing/test_sync_async_parity.py
@@ -12,71 +12,45 @@ public attribute names (anything not starting with ``_``) rather than callables 
 import pytest
 
 from ld_eventsource.async_client import AsyncSSEClient
-from ld_eventsource.config.async_connect_strategy import (AsyncConnectionClient,
-                                                          AsyncConnectionResult,
-                                                          AsyncConnectStrategy)
+from ld_eventsource.config.async_connect_strategy import (
+    AsyncConnectionClient, AsyncConnectionResult, AsyncConnectStrategy)
 from ld_eventsource.config.connect_strategy import (ConnectionClient,
                                                     ConnectionResult,
                                                     ConnectStrategy)
 from ld_eventsource.sse_client import SSEClient
-
-# Each entry pairs a public synchronous class with its asynchronous counterpart, plus
-# allowlists of names that are intentionally present on only one side. Every allowlisted
-# name must carry a justification; if the test flags a genuinely one-sided member, add it
-# here with a comment rather than weakening the comparison.
-_PAIRS = [
-    {
-        "sync": SSEClient,
-        "async": AsyncSSEClient,
-        # Names allowed to exist only on the sync class.
-        "sync_only": set(),
-        # Names allowed to exist only on the async class.
-        "async_only": set(),
-    },
-    {
-        "sync": ConnectStrategy,
-        "async": AsyncConnectStrategy,
-        "sync_only": set(),
-        "async_only": set(),
-    },
-    {
-        "sync": ConnectionClient,
-        "async": AsyncConnectionClient,
-        "sync_only": set(),
-        "async_only": set(),
-    },
-    {
-        "sync": ConnectionResult,
-        "async": AsyncConnectionResult,
-        "sync_only": set(),
-        "async_only": set(),
-    },
-]
 
 
 def _public_names(cls):
     return {name for name in dir(cls) if not name.startswith("_")} - set(dir(object))
 
 
+# Each param pairs a public synchronous class with its asynchronous counterpart, plus
+# allowlists of names intentionally present on only one side. Every allowlisted name must
+# carry a justification; if the test flags a genuinely one-sided member, add it here with a
+# comment rather than weakening the comparison.
 @pytest.mark.parametrize(
-    "pair",
-    _PAIRS,
-    ids=[f"{p['sync'].__name__}/{p['async'].__name__}" for p in _PAIRS],
+    "sync_cls, async_cls, sync_only, async_only",
+    [
+        pytest.param(SSEClient, AsyncSSEClient, set(), set(), id="SSEClient/AsyncSSEClient"),
+        pytest.param(ConnectStrategy, AsyncConnectStrategy, set(), set(), id="ConnectStrategy/AsyncConnectStrategy"),
+        pytest.param(ConnectionClient, AsyncConnectionClient, set(), set(), id="ConnectionClient/AsyncConnectionClient"),
+        pytest.param(ConnectionResult, AsyncConnectionResult, set(), set(), id="ConnectionResult/AsyncConnectionResult"),
+    ],
 )
-def test_sync_async_public_surface_matches(pair):
-    sync_names = _public_names(pair["sync"])
-    async_names = _public_names(pair["async"])
+def test_sync_async_public_surface_matches(sync_cls, async_cls, sync_only, async_only):
+    sync_names = _public_names(sync_cls)
+    async_names = _public_names(async_cls)
 
-    sync_only = sync_names - async_names - pair["sync_only"]
-    async_only = async_names - sync_names - pair["async_only"]
+    sync_only_diff = sync_names - async_names - sync_only
+    async_only_diff = async_names - sync_names - async_only
 
-    assert not sync_only, (
-        f"{pair['sync'].__name__} exposes public names with no counterpart on "
-        f"{pair['async'].__name__}: {sorted(sync_only)}. Add the missing member to the "
+    assert not sync_only_diff, (
+        f"{sync_cls.__name__} exposes public names with no counterpart on "
+        f"{async_cls.__name__}: {sorted(sync_only_diff)}. Add the missing member to the "
         f"async class, or allowlist it in 'sync_only' with a justification."
     )
-    assert not async_only, (
-        f"{pair['async'].__name__} exposes public names with no counterpart on "
-        f"{pair['sync'].__name__}: {sorted(async_only)}. Add the missing member to the "
+    assert not async_only_diff, (
+        f"{async_cls.__name__} exposes public names with no counterpart on "
+        f"{sync_cls.__name__}: {sorted(async_only_diff)}. Add the missing member to the "
         f"sync class, or allowlist it in 'async_only' with a justification."
     )

--- a/ld_eventsource/testing/test_sync_async_parity.py
+++ b/ld_eventsource/testing/test_sync_async_parity.py
@@ -1,0 +1,82 @@
+"""
+Parity guard for the hand-maintained synchronous and asynchronous client pairs.
+
+The sync and async implementations in this package are written and maintained by hand as
+parallel files. This test asserts that each public sync/async pair exposes the same public
+surface, so that a method or property added to one side but forgotten on the other fails CI.
+
+The public surface includes properties as well as methods, so the comparison is over all
+public attribute names (anything not starting with ``_``) rather than callables only.
+"""
+
+import pytest
+
+from ld_eventsource.async_client import AsyncSSEClient
+from ld_eventsource.config.async_connect_strategy import (AsyncConnectionClient,
+                                                          AsyncConnectionResult,
+                                                          AsyncConnectStrategy)
+from ld_eventsource.config.connect_strategy import (ConnectionClient,
+                                                    ConnectionResult,
+                                                    ConnectStrategy)
+from ld_eventsource.sse_client import SSEClient
+
+# Each entry pairs a public synchronous class with its asynchronous counterpart, plus
+# allowlists of names that are intentionally present on only one side. Every allowlisted
+# name must carry a justification; if the test flags a genuinely one-sided member, add it
+# here with a comment rather than weakening the comparison.
+_PAIRS = [
+    {
+        "sync": SSEClient,
+        "async": AsyncSSEClient,
+        # Names allowed to exist only on the sync class.
+        "sync_only": set(),
+        # Names allowed to exist only on the async class.
+        "async_only": set(),
+    },
+    {
+        "sync": ConnectStrategy,
+        "async": AsyncConnectStrategy,
+        "sync_only": set(),
+        "async_only": set(),
+    },
+    {
+        "sync": ConnectionClient,
+        "async": AsyncConnectionClient,
+        "sync_only": set(),
+        "async_only": set(),
+    },
+    {
+        "sync": ConnectionResult,
+        "async": AsyncConnectionResult,
+        "sync_only": set(),
+        "async_only": set(),
+    },
+]
+
+
+def _public_names(cls):
+    return {name for name in dir(cls) if not name.startswith("_")} - set(dir(object))
+
+
+@pytest.mark.parametrize(
+    "pair",
+    _PAIRS,
+    ids=[f"{p['sync'].__name__}/{p['async'].__name__}" for p in _PAIRS],
+)
+def test_sync_async_public_surface_matches(pair):
+    sync_names = _public_names(pair["sync"])
+    async_names = _public_names(pair["async"])
+
+    sync_only = sync_names - async_names - pair["sync_only"]
+    async_only = async_names - sync_names - pair["async_only"]
+
+    assert not sync_only, (
+        f"{pair['sync'].__name__} exposes public names with no counterpart on "
+        f"{pair['async'].__name__}: {sorted(sync_only)}. Add the missing member to the "
+        f"async class, or allowlist it in 'sync_only' with a justification."
+    )
+    assert not async_only, (
+        f"{pair['async'].__name__} exposes public names with no counterpart on "
+        f"{pair['sync'].__name__}: {sorted(async_only)}. Add the missing member to the "
+        f"sync class, or allowlist it in 'async_only' with a justification."
+    )


### PR DESCRIPTION
BEGIN_COMMIT_OVERRIDE
fix: Close the connection client on SSEClient.close()
fix: Update last_event_id as each event is yielded
END_COMMIT_OVERRIDE

Ports the genuine fixes surfaced by a throwaway `unasync` codegen experiment into the hand-maintained code. We decided **not** to adopt codegen for eventsource, so the generator and its Makefile targets are intentionally excluded — sync and async remain hand-written parallel files, guarded by a new parity test.

Opened as a **draft**: the async surface is being designated experimental and its release timing is coordinated with the async SDK work.

**Bug fix**
- `SSEClient.close()` now closes the underlying connection client (`connection_client.close()`), matching `AsyncSSEClient.close()`. Previously the connection client was never released when an `SSEClient` was closed, leaking its connection pool. (`_HttpClientImpl.close()` is a non-blocking `pool.clear()`.)

**Sync/async parity (internal, no public API change)**
- `_SSEReader.events_and_comments` is now a method, mirroring `_AsyncSSEReader`.
- `SSEClient.all`/`events` delegate to internal `_all_generator()`/`_events_generator()` helpers, mirroring `AsyncSSEClient`.
- `last_event_id` is updated as each event is yielded.
- The constructor's `TypeError` now names the `connect` parameter correctly.
- Connection-cleanup semantics are unchanged from `main` (re-reading `events`/`all` still resumes an open stream). Note: the experiment's `finally: close()` change was deliberately **not** ported — it regressed the sync re-read pattern.

**Experimental designation**
- Per LaunchDarkly SDK release standards (1.1.2 — non-GA features within a GA SDK must carry inline warnings at the method/property/configuration level), `AsyncSSEClient` and the public async configuration classes now carry the Experimental-stage (1.2.1) caution in their docstrings, with a matching `[!CAUTION]` note in the README. A companion sdk-specs PR adds an explicit Experimental-stage requirement (1.2.1.2) mirroring the Pre-release 1.2.2.2.

**Parity guard**
- New `test_sync_async_parity.py` asserts each public sync/async pair exposes the same public surface (properties included), so a member added to one side but forgotten on the other fails CI.

All 124 tests pass.

---

Changelog lines for release-please:
```
fix: Close the underlying connection client when SSEClient.close() is called
docs: Mark the async SSE client (AsyncSSEClient) as experimental
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are mostly documentation and internal structure; the `close()` fix is a targeted resource-lifecycle improvement with clear async precedent and existing test coverage.
> 
> **Overview**
> **`SSEClient.close()`** now calls **`connection_client.close()`**, aligning with **`AsyncSSEClient`** and releasing the underlying HTTP connection pool instead of leaking it on shutdown.
> 
> The **async SSE surface** (`AsyncSSEClient`, `AsyncConnectStrategy`, and related types) is documented as **experimental** via README `[!CAUTION]` and matching Sphinx `.. caution::` blocks, with guidance to pin minor versions.
> 
> **Internal sync/async parity** (no intended public API change): `_SSEReader.events_and_comments` is a method; `SSEClient.all` / `events` use `_all_generator()` / `_events_generator()`; **`last_event_id`** is refreshed while events are yielded; constructor **`TypeError`** refers to **`connect`** instead of `request`.
> 
> **`test_sync_async_parity.py`** compares public attribute names on each sync/async class pair so drift between hand-maintained implementations fails CI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a25c6dff39f19d8311c11aca31cd25f17fec7357. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->