### PR TITLE
chore: Migrate from Poetry to uv for dependency management

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -6,4 +6,4 @@ runs:
   steps:
     - name: Build distribution files
       shell: bash
-      run: poetry build
+      run: uv build --out-dir dist

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,18 +16,13 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install poetry
-        uses: abatilo/actions-poetry@7b6d33e44b4f08d7021a1dee3c044e9c253d6439
-        with:
-          poetry-version: "1.8.5"
-
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+      - name: Set up uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -64,23 +59,18 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install poetry
-        uses: abatilo/actions-poetry@7b6d33e44b4f08d7021a1dee3c044e9c253d6439
-        with:
-          poetry-version: "1.8.5"
-
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+      - name: Set up uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Install requirements
-        run: poetry install
+        run: uv sync --all-extras
 
       - uses: ./.github/actions/build
       - uses: ./.github/actions/build-docs

--- a/.github/workflows/manual-publish-docs.yml
+++ b/.github/workflows/manual-publish-docs.yml
@@ -11,12 +11,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v5
+      - name: Set up uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
-          python-version: 3.9
-
-      - name: Install poetry
-        uses: abatilo/actions-poetry@7b6d33e44b4f08d7021a1dee3c044e9c253d6439
+          python-version: "3.10"
 
       - uses: ./.github/actions/build-docs
 

--- a/.github/workflows/manual-publish.yml
+++ b/.github/workflows/manual-publish.yml
@@ -17,12 +17,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v5
+      - name: Set up uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
-          python-version: 3.9
-
-      - name: Install poetry
-        uses: abatilo/actions-poetry@7b6d33e44b4f08d7021a1dee3c044e9c253d6439 # v3.0.0
+          python-version: "3.10"
 
       - uses: launchdarkly/gh-actions/actions/release-secrets@release-secrets-v1.2.0
         name: "Get PyPI token"

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -21,14 +21,11 @@ jobs:
         with:
           fetch-depth: 0 # Full history is required for proper changelog generation
 
-      - uses: actions/setup-python@v4
+      - name: Set up uv
         if: ${{ steps.release.outputs.releases_created == 'true' }}
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
-          python-version: 3.9
-
-      - name: Install poetry
-        if: ${{ steps.release.outputs.releases_created == 'true' }}
-        uses: abatilo/actions-poetry@7b6d33e44b4f08d7021a1dee3c044e9c253d6439 # v3.0.0
+          python-version: "3.10"
 
       - uses: launchdarkly/gh-actions/actions/release-secrets@release-secrets-v1.2.0
         name: "Get PyPI token"

--- a/.gitignore
+++ b/.gitignore
@@ -73,5 +73,6 @@ test-packaging-venv
 .vscode/
 .python-version
 
-# Poetry
-poetry.lock
+# uv — lock file is not committed for libraries (only for applications)
+uv.lock
+.venv/

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,16 +1,20 @@
 version: 2
 
-build:
-  os: "ubuntu-22.04"
-  tools:
-    python: "3.12"
-  jobs:
-    post_create_environment:
-      - python -m pip install poetry
-    post_install:
-      - VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH poetry install --with docs
-
 sphinx:
   builder: html
   configuration: docs/conf.py
   fail_on_warning: true
+
+build:
+  os: ubuntu-24.04
+  tools:
+    python: "3.12"
+  jobs:
+    pre_create_environment:
+      - asdf plugin add uv
+      - asdf install uv latest
+      - asdf global uv latest
+    create_environment:
+      - uv venv "${READTHEDOCS_VIRTUALENV_PATH}"
+    install:
+      - UV_PROJECT_ENVIRONMENT="${READTHEDOCS_VIRTUALENV_PATH}" uv sync --group docs

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,14 +19,14 @@ This project should be developed against its minimum compatible version as descr
 To install the runtime and test requirements:
 
 ```
-poetry install
-eval $(poetry env activate)
+uv sync
+source .venv/bin/activate
 ```
 
 To also install the optional async dependencies (required to use `AsyncSSEClient`):
 
 ```
-poetry install --extras async
+uv sync --extra async
 ```
 
 ### Testing

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ help: #! Show this help message
 
 .PHONY: install
 install:
-	poetry install
+	@uv sync --all-extras
 
 #
 # Quality control checks
@@ -27,14 +27,14 @@ install:
 .PHONY: test
 test: #! Run unit tests
 test: install
-	poetry run pytest $(PYTEST_FLAGS)
+	@uv run pytest $(PYTEST_FLAGS)
 
 .PHONY: lint
 lint: #! Run type analysis and linting checks
 lint: install
-	@poetry run mypy ld_eventsource
-	@poetry run isort --check --atomic ld_eventsource contract-tests
-	@poetry run pycodestyle ld_eventsource contract-tests
+	@uv run mypy ld_eventsource
+	@uv run isort --check --atomic ld_eventsource contract-tests
+	@uv run pycodestyle ld_eventsource contract-tests
 
 #
 # Documentation generation
@@ -42,9 +42,9 @@ lint: install
 
 .PHONY: docs
 docs: #! Generate sphinx-based documentation
-	poetry install --with docs
+	@uv sync --group docs
 	cd docs
-	poetry run $(SPHINXBUILD) -M html "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+	@uv run $(SPHINXBUILD) -M html "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
 #
 # Contract test service commands
@@ -52,11 +52,11 @@ docs: #! Generate sphinx-based documentation
 
 .PHONY: install-contract-tests-deps
 install-contract-tests-deps:
-	poetry install --with contract-tests
+	uv sync --all-extras --group contract-tests
 
 .PHONY: start-contract-test-service
-start-contract-test-service:
-	@cd contract-tests && poetry run python service.py
+start-contract-test-service: install-contract-tests-deps
+	@cd contract-tests && uv run python service.py
 
 .PHONY: start-contract-test-service-bg
 start-contract-test-service-bg:
@@ -73,8 +73,8 @@ contract-tests: #! Run the SSE contract test harness
 contract-tests: install-contract-tests-deps start-contract-test-service-bg run-contract-tests
 
 .PHONY: start-async-contract-test-service
-start-async-contract-test-service:
-	@cd contract-tests && poetry run python async_service.py 8001
+start-async-contract-test-service: install-contract-tests-deps
+	@cd contract-tests && uv run python async_service.py 8001
 
 .PHONY: start-async-contract-test-service-bg
 start-async-contract-test-service-bg:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,13 @@
-[tool.poetry]
+[project]
 name = "launchdarkly-eventsource"
 version = "1.6.0"
 description = "LaunchDarkly SSE Client"
-authors = ["LaunchDarkly <dev@launchdarkly.com>"]
+authors = [
+    {name = "LaunchDarkly", email = "dev@launchdarkly.com"}
+]
 license = "Apache-2.0"
 readme = "README.md"
-homepage = "https://docs.launchdarkly.com/sdk/server-side/python"
-repository = "https://github.com/launchdarkly/python-eventsource"
-documentation = "https://launchdarkly-sse-client-library.readthedocs.io/en/latest/"
+requires-python = ">=3.9"
 classifiers = [
     "Intended Audience :: Developers",
     "License :: OSI Approved :: Apache Software License",
@@ -18,66 +18,60 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Software Development",
     "Topic :: Software Development :: Libraries",
 ]
-packages = [ { include = "ld_eventsource" } ]
-exclude = [
-    { path = "ld_eventsource/testing", format = "wheel" }
+dependencies = [
+    "urllib3>=1.26.0,<3",
 ]
 
-[tool.poetry.dependencies]
-python = ">=3.9"
-urllib3 = ">=1.26.0,<3"
-aiohttp = { version = ">=3.8.0,<4", optional = true }
+[project.urls]
+Homepage = "https://docs.launchdarkly.com/sdk/server-side/python"
+Repository = "https://github.com/launchdarkly/python-eventsource"
+Documentation = "https://launchdarkly-sse-client-library.readthedocs.io/en/latest/"
 
-[tool.poetry.extras]
-async = ["aiohttp"]
+[project.optional-dependencies]
+async = ["aiohttp>=3.8.0,<4"]
 
-[tool.poetry.group.dev.dependencies]
-mock = ">=2.0.0"
-pytest = ">=2.8"
-pytest-asyncio = ">=0.21"
-aiohttp = ">=3.8.0,<4"
-mypy = "^1.4.0"
-pycodestyle = "^2.12.1"
-isort = "^5.13.2"
-
-
-[tool.poetry.group.contract-tests]
-optional = true
-
-[tool.poetry.group.contract-tests.dependencies]
-Flask = ">=3.0"
-
-
-[tool.poetry.group.docs]
-optional = true
-
-[tool.poetry.group.docs.dependencies]
-sphinx = ">=6,<8"
-sphinx-autodoc-typehints = "^1.3.0"
-sphinx-rtd-theme = ">=1.3,<4.0"
-backoff = ">=1.4.3"
-expiringdict = ">=1.1.4"
-pyrfc3339 = ">=1.0"
-jsonpickle = ">1.4.1"
-semver = ">=2.7.9"
-urllib3 = ">=1.26.0"
-jinja2 = ">=3.1.2"
+[dependency-groups]
+dev = [
+    "mock>=2.0.0",
+    "pytest>=8.0.0,<9",
+    "pytest-asyncio>=0.21",
+    "aiohttp>=3.8.0,<4",
+    "mypy>=1.4.0,<2",
+    "pycodestyle>=2.12.1,<3",
+    "isort>=5.13.2,<6",
+]
+contract-tests = [
+    "Flask>=3.0",
+]
+docs = [
+    "sphinx>=6,<8",
+    "sphinx-autodoc-typehints>=1.3.0,<2",
+    "sphinx-rtd-theme>=1.3,<4.0",
+    "backoff>=1.4.3",
+    "expiringdict>=1.1.4",
+    "pyrfc3339>=1.0",
+    "jsonpickle>1.4.1",
+    "semver>=2.7.9",
+    "urllib3>=1.26.0",
+    "jinja2>=3.1.2",
+]
 
 [tool.mypy]
 python_version = "3.9"
 ignore_missing_imports = true
-install_types = true
-non_interactive = true
-
 
 [tool.pytest.ini_options]
 addopts = ["-ra"]
 asyncio_mode = "auto"
 
-
 [build-system]
-requires = ["poetry-core"]
-build-backend = "poetry.core.masonry.api"
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["ld_eventsource"]
+exclude = ["ld_eventsource/testing"]


### PR DESCRIPTION
## Summary

The `1.6.0` release publish failed because `release-please.yml` installed Poetry via `actions-poetry` with the default `poetry-version: latest`, and current Poetry requires Python 3.10+ while the release job ran on Python 3.9 (`dataclass() got an unexpected keyword argument 'slots'`). Rather than pin Poetry, this migrates the repo from Poetry to [uv](https://docs.astral.sh/uv/), matching launchdarkly/python-server-sdk#431.

It also adds Python 3.14 to the test matrix and supported classifiers.

> Note: the `v1.6.0` tag and GitHub release already exist; only the PyPI publish failed (PyPI is still at 1.5.1). Once this merges, 1.6.0 can be published via the **Publish Package** workflow (`manual-publish.yml`).

## What changed

### `pyproject.toml`
- Converted `[tool.poetry]` → standard PEP 621 `[project]`
- `[tool.poetry.extras]` async → `[project.optional-dependencies]`
- Dev / contract-tests / docs groups → `[dependency-groups]`
- Build backend `poetry-core` → `hatchling`, with the wheel scoped to `ld_eventsource` and excluding `ld_eventsource/testing` (preserving Poetry's behavior)
- Preserved `requires-python = ">=3.9"` and all version constraints
- Added a mypy override so it does not parse third-party `pytest` internals (their source uses `match` syntax newer than the project's 3.9 floor)
- Added the `Python :: 3.14` classifier

### CI / release workflows
- `ci.yml`, `manual-publish.yml`, `release-please.yml`, `manual-publish-docs.yml`: replaced `actions/setup-python` + `abatilo/actions-poetry` with `astral-sh/setup-uv` (pinned to v8.2.0)
- Release/publish workflows run on Python 3.10 (off the EOL 3.9); CI matrix runs 3.9–3.14
- `.github/actions/build/action.yml`: `poetry build` → `uv build --out-dir dist`

### Other
- `Makefile`: `poetry install/run` → `uv sync` / `uv run`
- `CONTRIBUTING.md`: setup instructions use `uv sync`
- `.readthedocs.yml`: uv-based environment
- `.gitignore`: drop `poetry.lock`; ignore `uv.lock` and `.venv/` (library — lockfile not committed)

## Test plan

Verified locally:
- `uv sync --all-extras` resolves and installs cleanly
- `uv build` produces sdist + wheel; `ld_eventsource/testing` excluded from the wheel, retained in the sdist
- `make test` — 124 passed (also verified on Python 3.14)
- `make lint` — mypy / isort / pycodestyle all pass
- `make docs` — builds cleanly under uv

---