### PR TITLE
feat: Drop support for Python 3.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - uses: actions/checkout@v4
@@ -59,7 +59,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ pip install launchdarkly-eventsource[async]
 
 ## Supported Python versions
 
-This version of the package is compatible with Python 3.9 and higher.
+This version of the package is compatible with Python 3.10 and higher.
 
 ## Contributing
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,13 +7,12 @@ authors = [
 ]
 license = "Apache-2.0"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 classifiers = [
     "Intended Audience :: Developers",
     "License :: OSI Approved :: Apache Software License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -61,7 +60,7 @@ docs = [
 ]
 
 [tool.mypy]
-python_version = "3.9"
+python_version = "3.10"
 ignore_missing_imports = true
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
BEGIN_COMMIT_OVERRIDE
feat: Drop support for Python 3.9
END_COMMIT_OVERRIDE

## Summary

Drops support for Python 3.9, which is [end of life](https://devguide.python.org/versions/) as of October 2025. The new minimum supported version is **Python 3.10**.

Dropping an EOL Python version is not considered a breaking change under our SDK support policy, so this is released as a `feat` (not `feat!`).

## What changed

- `pyproject.toml`: `requires-python` `>=3.9` → `>=3.10`; removed the `Python :: 3.9` classifier; `[tool.mypy] python_version` `3.9` → `3.10`
- `.github/workflows/ci.yml`: dropped `3.9` from the test matrix (now 3.10–3.14, both Linux and Windows jobs)
- `README.md`: "compatible with Python 3.10 and higher"

The release/publish workflows already run on Python 3.10 (set in #68), so they're now consistent with the floor.

## Test plan

Verified locally on Python 3.10 (the new floor):
- `make test` — 124 passed
- `make lint` — mypy / isort / pycodestyle all pass

feat: Drop support for Python 3.9

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata and CI-only changes; users still on 3.9 will be blocked at install time but runtime library behavior is unchanged in this diff.
> 
> **Overview**
> Raises the **minimum supported Python version to 3.10**, dropping end-of-life **3.9** from packaging, docs, and CI.
> 
> `pyproject.toml` now sets `requires-python = ">=3.10"`, removes the PyPI `Python :: 3.9` classifier, and points **mypy** at `python_version = "3.10"`. The **Linux and Windows** CI matrices test **3.10–3.14** only. **README** states compatibility with Python 3.10 and higher.
> 
> No application/library source changes are in this diff—only support policy and tooling alignment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0328a25fc0552f5b0e85c94f900491d72b852dc8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->