### PR TITLE
fix: Correct pool ownership and close pooled connections synchronously

### DIFF
--- a/ld_eventsource/http.py
+++ b/ld_eventsource/http.py
@@ -57,7 +57,7 @@ class _HttpClientImpl:
     def __init__(self, params: _HttpConnectParams, logger: Logger):
         self.__params = params
         self.__pool = params.pool or PoolManager()
-        self.__should_close_pool = params.pool is not None
+        self.__should_close_pool = params.pool is None
         self.__logger = logger
 
     def connect(self, last_event_id: Optional[str]) -> Tuple[Iterator[bytes], Callable, Dict[str, Any]]:
@@ -125,4 +125,14 @@ class _HttpClientImpl:
 
     def close(self):
         if self.__should_close_pool:
+            # Close pooled connections (sends the TCP FIN) before dropping the pool.
+            # PoolManager.clear() alone drops the pool dict without closing the
+            # underlying sockets, leaving the connection open until garbage collection.
+            for key in list(self.__pool.pools.keys()):
+                connection_pool = self.__pool.pools.get(key)
+                if connection_pool is not None:
+                    try:
+                        connection_pool.close()
+                    except Exception:
+                        self.__logger.debug("Error closing connection pool", exc_info=True)
             self.__pool.clear()

--- a/ld_eventsource/testing/test_http_connect_strategy.py
+++ b/ld_eventsource/testing/test_http_connect_strategy.py
@@ -1,5 +1,7 @@
 import logging
+from unittest import mock
 
+from urllib3 import PoolManager
 from urllib3.exceptions import ProtocolError
 
 from ld_eventsource import *
@@ -239,3 +241,34 @@ def test_fault_exposes_headers_from_http_error():
             assert fault.headers is not None
             assert fault.headers.get('Retry-After') == '60'
             assert fault.headers.get('X-Error-Code') == 'SERVICE_UNAVAILABLE'
+
+
+def test_close_leaves_caller_supplied_pool_open():
+    # The caller owns the lifecycle of a pool it supplies, so close() must not
+    # tear it down. (Regression: this ownership flag was inverted, causing the
+    # client to clear() a caller-supplied pool out from under the caller.)
+    pool = mock.MagicMock(spec=PoolManager)
+    client = ConnectStrategy.http("http://test", pool=pool).create_client(logger())
+
+    client.close()
+
+    pool.clear.assert_not_called()
+
+
+def test_close_closes_pool_it_created():
+    # When the client creates its own pool (no pool supplied), close() must close
+    # the pooled connections synchronously -- sending the TCP FIN now -- rather
+    # than leaving the sockets open until garbage collection. PoolManager.clear()
+    # alone does not close them on urllib3 2.x.
+    connection_pool = mock.Mock()
+    created_pool = mock.MagicMock()
+    created_pool.pools.keys.return_value = ['poolkey']
+    created_pool.pools.get.return_value = connection_pool
+
+    with mock.patch('ld_eventsource.http.PoolManager', return_value=created_pool):
+        client = ConnectStrategy.http("http://test").create_client(logger())
+
+    client.close()
+
+    connection_pool.close.assert_called_once()
+    created_pool.clear.assert_called_once()


### PR DESCRIPTION
## What

`_HttpClientImpl` owned the wrong pool. The ownership flag was inverted in the 2023 ConnectStrategy refactor (`c516f1f8`): it was renamed from `http_pool is None` (close a pool the library created) to `params.pool is not None` (close a caller-supplied pool). Combined with urllib3 2.x — where `PoolManager.clear()` no longer closes connections synchronously (no `dispose_func`; sockets close via `weakref.finalize` at GC time) — this meant:

- A **caller-supplied** pool was `clear()`-ed out from under the caller on `close()`, and the underlying streaming socket's TCP FIN was deferred to garbage collection.
- A **library-created** pool was never closed at all (leaked until GC).

The async client (`async_http.py`) already uses the correct rule (`external_session is None`), so this also brings the sync client back into line with it.

## Changes

- `__should_close_pool = params.pool is None` — own only the pool we created; leave a caller-supplied pool to the caller.
- `close()` closes each `HTTPConnectionPool` synchronously (sends the FIN now) before `clear()`.
- Close errors logged at debug instead of silently swallowed.
- Regression tests in `test_http_connect_strategy.py` for both halves of the ownership contract (there was previously **zero** coverage, which is why the inversion survived since 2023).

## Why it matters

The LaunchDarkly server SDKs supply their own pool for FDv2 streaming. On the FDv1 fallback directive the SDK must close the streaming connection within 3s (spec 1.6.3(2)). Because the FIN was GC-deferred, the FDv2 contract test `directive on streaming success applies payload then engages FDv1` failed on slow CI runners (Linux + Python 3.10) where GC slipped past the 3s window.

## Verification

Instrumented FDv1-fallback contract run under Python 3.10:

| | Streaming FIN after halt | Mechanism |
|---|---|---|
| Before | ~0.56 s | `weakref.finalize` (GC) |
| After | ~0.0006 s | synchronous, in the SDK's pool-close call stack |

GC-deferred (~560 ms, variable) → synchronous (~0.6 ms, deterministic), well within the 3s window regardless of machine speed. Full unit suite: 126 passed.

Jira: SDK-2600

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches connection lifecycle for all sync HTTP SSE clients; behavior change is intentional but affects SDK streaming shutdown timing and caller-supplied pool safety.
> 
> **Overview**
> Fixes **inverted `PoolManager` ownership** in `_HttpClientImpl`: `close()` now tears down only pools the client created (`params.pool is None`), matching the async client’s `external_session is None` rule. Caller-supplied pools are no longer `clear()`’d on close.
> 
> When the client owns the pool, **`close()` now closes each `HTTPConnectionPool` before `PoolManager.clear()`**, so streaming TCP connections get a FIN immediately instead of lingering until urllib3 2.x GC/finalizers. Close failures are logged at debug.
> 
> Adds **regression tests** for both ownership paths (caller pool untouched vs. internally created pool closed + cleared).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce86c6ef43e497545124f48ee668a09da2f0a12a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->