### PR TITLE
fix: Close streaming connections deterministically where the platform allows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,13 +78,10 @@ jobs:
       - name: Run tests
         run: make test
 
-  # Guards the minimum declared dependency versions (e.g. urllib3 1.26, which
-  # lacks HTTPResponse.shutdown()) on both platforms, since the regular jobs run
-  # against the locked/latest versions. One Python; not a full version matrix.
+  # Guards the minimum declared dependency versions, since the regular jobs
+  # run against the locked/latest versions. 
   floor:
     name: floor (lowest-direct deps)
-    # uv reads UV_RESOLUTION, so both `uv sync` (install) and `uv run pytest`
-    # in `make test` resolve the minimum declared versions.
     env:
       UV_RESOLUTION: lowest-direct
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,3 +77,25 @@ jobs:
 
       - name: Run tests
         run: make test
+
+  # Guards the minimum declared dependency versions (e.g. urllib3 1.26, which
+  # lacks HTTPResponse.shutdown()) on both platforms, since the regular jobs run
+  # against the locked/latest versions. One Python; not a full version matrix.
+  floor:
+    name: floor (lowest-direct deps)
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          python-version: "3.10"
+
+      - name: Run tests against lowest-direct dependency versions
+        run: uv run --resolution lowest-direct --all-extras pytest ld_eventsource/testing

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,10 @@ jobs:
   # against the locked/latest versions. One Python; not a full version matrix.
   floor:
     name: floor (lowest-direct deps)
+    # uv reads UV_RESOLUTION, so both `uv sync` (install) and `uv run pytest`
+    # in `make test` resolve the minimum declared versions.
+    env:
+      UV_RESOLUTION: lowest-direct
     strategy:
       fail-fast: false
       matrix:
@@ -97,5 +101,5 @@ jobs:
         with:
           python-version: "3.10"
 
-      - name: Run tests against lowest-direct dependency versions
-        run: uv run --resolution lowest-direct --all-extras pytest ld_eventsource/testing
+      - name: Run tests
+        run: make test

--- a/ld_eventsource/http.py
+++ b/ld_eventsource/http.py
@@ -115,24 +115,31 @@ class _HttpClientImpl:
         stream = resp.stream(_CHUNK_SIZE)
 
         def close():
-            try:
-                resp.shutdown()
-            except Exception:
-                pass
-            resp.release_conn()
+            if hasattr(resp, "shutdown"):
+                # urllib3 2.x: shutdown() wakes a reader blocked mid-read (SHUT_RD) so the
+                # subsequent close() -- which calls self._fp.close() and would otherwise
+                # deadlock on the reader's BufferedReader lock -- can proceed. close() then
+                # sends the TCP FIN and releases the fd. Both are built-ins.
+                try:
+                    resp.shutdown()
+                except Exception:
+                    self.__logger.debug("Error interrupting stream via resp.shutdown()", exc_info=True)
+                resp.close()
+            else:
+                # urllib3 1.26.x has no resp.shutdown(), and we deliberately do not reach
+                # into private socket attributes to find and shut down the socket. Without a
+                # way to wake a blocked reader first, resp.close() could deadlock on the
+                # reader's BufferedReader lock, so we fall back to the original behavior of
+                # releasing the connection back to the pool. This never hangs, but the socket
+                # is not closed deterministically -- deterministic close requires urllib3 2.x.
+                resp.release_conn()
 
         return stream, close, response_headers
 
     def close(self):
         if self.__should_close_pool:
-            # Close pooled connections (sends the TCP FIN) before dropping the pool.
-            # PoolManager.clear() alone drops the pool dict without closing the
-            # underlying sockets, leaving the connection open until garbage collection.
-            for key in list(self.__pool.pools.keys()):
-                connection_pool = self.__pool.pools.get(key)
-                if connection_pool is not None:
-                    try:
-                        connection_pool.close()
-                    except Exception:
-                        self.__logger.debug("Error closing connection pool", exc_info=True)
+            # Only clear a pool we created. On urllib3 2.x the active connection was already
+            # closed by the connection closer (resp.close()); we do not iterate and close the
+            # pool's connections ourselves, because doing so hangs on urllib3 1.26.x when a
+            # reader is still blocked mid-read on a connection.
             self.__pool.clear()

--- a/ld_eventsource/http.py
+++ b/ld_eventsource/http.py
@@ -115,31 +115,16 @@ class _HttpClientImpl:
         stream = resp.stream(_CHUNK_SIZE)
 
         def close():
-            if hasattr(resp, "shutdown"):
-                # urllib3 2.x: shutdown() wakes a reader blocked mid-read (SHUT_RD) so the
-                # subsequent close() -- which calls self._fp.close() and would otherwise
-                # deadlock on the reader's BufferedReader lock -- can proceed. close() then
-                # sends the TCP FIN and releases the fd. Both are built-ins.
-                try:
-                    resp.shutdown()
-                except Exception:
-                    self.__logger.debug("Error interrupting stream via resp.shutdown()", exc_info=True)
-                resp.close()
-            else:
-                # urllib3 1.26.x has no resp.shutdown(), and we deliberately do not reach
-                # into private socket attributes to find and shut down the socket. Without a
-                # way to wake a blocked reader first, resp.close() could deadlock on the
-                # reader's BufferedReader lock, so we fall back to the original behavior of
-                # releasing the connection back to the pool. This never hangs, but the socket
-                # is not closed deterministically -- deterministic close requires urllib3 2.x.
-                resp.release_conn()
+            try:
+                resp.shutdown()
+            except Exception:
+                self.__logger.debug("Error interrupting stream via resp.shutdown()", exc_info=True)
+            resp.close()
 
         return stream, close, response_headers
 
     def close(self):
         if self.__should_close_pool:
-            # Only clear a pool we created. On urllib3 2.x the active connection was already
-            # closed by the connection closer (resp.close()); we do not iterate and close the
-            # pool's connections ourselves, because doing so hangs on urllib3 1.26.x when a
-            # reader is still blocked mid-read on a connection.
+            # Only clear a pool we created; the active connection was already closed by the
+            # connection closer (resp.close()), so clearing the pool is all that's left.
             self.__pool.clear()

--- a/ld_eventsource/http.py
+++ b/ld_eventsource/http.py
@@ -1,3 +1,4 @@
+import sys
 from logging import Logger
 from typing import Any, Callable, Dict, Iterator, Optional, Tuple, cast
 from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
@@ -115,24 +116,33 @@ class _HttpClientImpl:
         stream = resp.stream(_CHUNK_SIZE)
 
         def close():
-            try:
-                resp.shutdown()
-            except Exception:
-                self.__logger.debug("Error interrupting stream via resp.shutdown()", exc_info=True)
-            # Close the connection's socket directly (public API) to also wake a
-            # blocked reader on Windows, where resp.shutdown() does not interrupt recv().
-            conn = resp.connection
-            if conn is not None:
-                try:
-                    conn.close()
-                except Exception:
-                    self.__logger.debug("Error closing stream connection", exc_info=True)
-            resp.close()
+            # We can only deterministically close the socket where a reader blocked
+            # mid-read can first be woken: POSIX with urllib3's resp.shutdown()
+            # (SHUT_RD). On Windows (shutdown() does not interrupt recv()) or on
+            # urllib3 without shutdown(), release instead -- the socket leaks until
+            # GC but this never deadlocks on the reader's BufferedReader lock.
+            if sys.platform != "win32" and hasattr(resp, "shutdown"):
+                if resp.connection is not None:
+                    try:
+                        resp.shutdown()
+                    except Exception:
+                        self.__logger.debug("Error interrupting stream via resp.shutdown()", exc_info=True)
+                resp.close()
+            else:
+                resp.release_conn()
 
         return stream, close, response_headers
 
     def close(self):
         if self.__should_close_pool:
-            # Only clear a pool we created; the active connection was already closed by the
-            # connection closer (resp.close()), so clearing the pool is all that's left.
+            # Close pooled connections (sends the TCP FIN) before dropping the pool.
+            # PoolManager.clear() alone drops the pool dict without closing the
+            # underlying sockets, leaving the connection open until garbage collection.
+            for key in list(self.__pool.pools.keys()):
+                connection_pool = self.__pool.pools.get(key)
+                if connection_pool is not None:
+                    try:
+                        connection_pool.close()
+                    except Exception:
+                        self.__logger.debug("Error closing connection pool", exc_info=True)
             self.__pool.clear()

--- a/ld_eventsource/http.py
+++ b/ld_eventsource/http.py
@@ -119,6 +119,14 @@ class _HttpClientImpl:
                 resp.shutdown()
             except Exception:
                 self.__logger.debug("Error interrupting stream via resp.shutdown()", exc_info=True)
+            # Close the connection's socket directly (public API) to also wake a
+            # blocked reader on Windows, where resp.shutdown() does not interrupt recv().
+            conn = resp.connection
+            if conn is not None:
+                try:
+                    conn.close()
+                except Exception:
+                    self.__logger.debug("Error closing stream connection", exc_info=True)
             resp.close()
 
         return stream, close, response_headers

--- a/ld_eventsource/sse_client.py
+++ b/ld_eventsource/sse_client.py
@@ -168,6 +168,19 @@ class SSEClient:
             self.__connection_result = None
             self._compute_next_retry_delay()
 
+    def _close_current_connection(self):
+        # Close the current connection before dropping it so a fault-driven reconnect tears
+        # the old connection down deterministically (on urllib3 2.x) rather than deferring to
+        # garbage collection. This is only reached after the read loop has ended (stream
+        # exhausted or errored), so the reader is not blocked mid-read and closing cannot
+        # deadlock. Capture into a local and guard for None in case interrupt() nulled it
+        # concurrently; ConnectionResult.close() is idempotent, so a later interrupt()/close()
+        # is safe.
+        result = self.__connection_result
+        self.__connection_result = None
+        if result is not None:
+            result.close()
+
     @property
     def all(self) -> Iterable[Action]:
         """
@@ -218,13 +231,13 @@ class SSEClient:
                         break
                 # If we finished iterating all of reader.events_and_comments(), it means the stream
                 # was closed without an error.
-                self.__connection_result = None
+                self._close_current_connection()
             except Exception as e:
                 if self.__closed:
                     # It's normal to get an I/O error if we force-closed the stream to shut down
                     return
                 error = e
-                self.__connection_result = None
+                self._close_current_connection()
             finally:
                 self.__last_event_id = reader.last_event_id
 

--- a/ld_eventsource/sse_client.py
+++ b/ld_eventsource/sse_client.py
@@ -164,18 +164,11 @@ class SSEClient:
         """
         if self.__connection_result:
             self.__interrupted = True
-            self.__connection_result.close()
-            self.__connection_result = None
+            self._close_current_connection()
             self._compute_next_retry_delay()
 
     def _close_current_connection(self):
-        # Close the current connection before dropping it so a fault-driven reconnect tears
-        # the old connection down deterministically (on urllib3 2.x) rather than deferring to
-        # garbage collection. This is only reached after the read loop has ended (stream
-        # exhausted or errored), so the reader is not blocked mid-read and closing cannot
-        # deadlock. Capture into a local and guard for None in case interrupt() nulled it
-        # concurrently; ConnectionResult.close() is idempotent, so a later interrupt()/close()
-        # is safe.
+        # Close and drop the current connection, if any.
         result = self.__connection_result
         self.__connection_result = None
         if result is not None:

--- a/ld_eventsource/testing/test_http_connect_strategy.py
+++ b/ld_eventsource/testing/test_http_connect_strategy.py
@@ -256,14 +256,10 @@ def test_close_leaves_caller_supplied_pool_open():
 
 
 def test_close_clears_pool_it_created():
-    # When the client creates its own pool (no pool supplied), close() clears that pool.
-    # It must NOT iterate and close the individual connection pools itself: on urllib3
-    # 1.26.x that hangs when a reader is still blocked mid-read on a connection. On
-    # urllib3 2.x the active connection is already closed by the connection closer.
-    connection_pool = mock.Mock()
+    # When the client creates its own pool (no pool supplied), close() clears it. The active
+    # connection is already closed by the connection closer (resp.close()), so clearing the
+    # pool is all that's needed here.
     created_pool = mock.MagicMock()
-    created_pool.pools.keys.return_value = ['poolkey']
-    created_pool.pools.get.return_value = connection_pool
 
     with mock.patch('ld_eventsource.http.PoolManager', return_value=created_pool):
         client = ConnectStrategy.http("http://test").create_client(logger())
@@ -271,4 +267,3 @@ def test_close_clears_pool_it_created():
     client.close()
 
     created_pool.clear.assert_called_once()
-    connection_pool.close.assert_not_called()

--- a/ld_eventsource/testing/test_http_connect_strategy.py
+++ b/ld_eventsource/testing/test_http_connect_strategy.py
@@ -256,14 +256,18 @@ def test_close_leaves_caller_supplied_pool_open():
 
 
 def test_close_clears_pool_it_created():
-    # When the client creates its own pool (no pool supplied), close() clears it. The active
-    # connection is already closed by the connection closer (resp.close()), so clearing the
-    # pool is all that's needed here.
+    # When the client creates its own pool (no pool supplied), close() closes the pooled
+    # connections (to send FIN, since PoolManager.clear() does not on urllib3 2.x) and
+    # then clears the pool.
+    connection_pool = mock.Mock()
     created_pool = mock.MagicMock()
+    created_pool.pools.keys.return_value = ['poolkey']
+    created_pool.pools.get.return_value = connection_pool
 
     with mock.patch('ld_eventsource.http.PoolManager', return_value=created_pool):
         client = ConnectStrategy.http("http://test").create_client(logger())
 
     client.close()
 
+    connection_pool.close.assert_called_once()
     created_pool.clear.assert_called_once()

--- a/ld_eventsource/testing/test_http_connect_strategy.py
+++ b/ld_eventsource/testing/test_http_connect_strategy.py
@@ -255,11 +255,11 @@ def test_close_leaves_caller_supplied_pool_open():
     pool.clear.assert_not_called()
 
 
-def test_close_closes_pool_it_created():
-    # When the client creates its own pool (no pool supplied), close() must close
-    # the pooled connections synchronously -- sending the TCP FIN now -- rather
-    # than leaving the sockets open until garbage collection. PoolManager.clear()
-    # alone does not close them on urllib3 2.x.
+def test_close_clears_pool_it_created():
+    # When the client creates its own pool (no pool supplied), close() clears that pool.
+    # It must NOT iterate and close the individual connection pools itself: on urllib3
+    # 1.26.x that hangs when a reader is still blocked mid-read on a connection. On
+    # urllib3 2.x the active connection is already closed by the connection closer.
     connection_pool = mock.Mock()
     created_pool = mock.MagicMock()
     created_pool.pools.keys.return_value = ['poolkey']
@@ -270,5 +270,5 @@ def test_close_closes_pool_it_created():
 
     client.close()
 
-    connection_pool.close.assert_called_once()
     created_pool.clear.assert_called_once()
+    connection_pool.close.assert_not_called()

--- a/ld_eventsource/testing/test_http_connect_strategy_with_sse_client.py
+++ b/ld_eventsource/testing/test_http_connect_strategy_with_sse_client.py
@@ -1,6 +1,11 @@
+import threading
+import time
 from urllib.parse import parse_qsl
 
+import urllib3.response
+
 from ld_eventsource import *
+from ld_eventsource.actions import *
 from ld_eventsource.config import *
 from ld_eventsource.testing.helpers import *
 from ld_eventsource.testing.http_util import *
@@ -56,6 +61,113 @@ def test_sse_client_reconnects_after_socket_closed():
                     event2 = next(client.events)
                     assert event2.event == 'b'
                     assert event2.data == 'data2'
+
+
+def test_sse_client_reconnects_after_interrupt():
+    # interrupt() now fully closes the active HTTP connection (resp.close()) rather than
+    # releasing it back to the pool, so this verifies the client can still open a fresh
+    # stream and reconnect after an interrupt.
+    with start_server() as server:
+        with make_stream() as stream1:
+            with make_stream() as stream2:
+                server.for_path('/', SequentialHandler(stream1, stream2))
+                stream1.push("event: a\ndata: data1\n\n")
+                stream2.push("event: b\ndata: data2\n\n")
+                with SSEClient(
+                    connect=ConnectStrategy.http(server.uri),
+                    error_strategy=ErrorStrategy.always_continue(),
+                    initial_retry_delay=0,
+                ) as client:
+                    client.start()
+                    event1 = next(client.events)
+                    assert event1.event == 'a'
+                    assert event1.data == 'data1'
+
+                    # interrupt() closes the active connection (resp.close()); the
+                    # client discards it and will open a fresh stream on the next read.
+                    client.interrupt()
+
+                    # Release the first server-side handler so this single-threaded test
+                    # server can accept the reconnect. (The reconnect itself is driven by
+                    # the interrupt above, not by this close.)
+                    stream1.close()
+
+                    event2 = next(client.events)
+                    assert event2.event == 'b'
+                    assert event2.data == 'data2'
+
+
+# urllib3 2.x exposes HTTPResponse.shutdown(), which lets the closer wake a reader that is
+# blocked mid-read before closing the connection. urllib3 1.26.x has no such built-in, and
+# under design U-prime we deliberately do not reach into private socket attributes to wake
+# the reader. So on 2.x the reader is woken; on 1.26.x it is not -- but in NEITHER case may
+# the stop call itself hang.
+_CAN_WAKE_READER = hasattr(urllib3.response.HTTPResponse, "shutdown")
+
+
+def _run_concurrent_stop_test(stop_method_name):
+    # Exercises the concurrent shutdown pattern: a worker thread blocks mid-read on an idle
+    # stream while another thread stops the client. The stop call must return within the
+    # timeout on every urllib3 version (a hang here is the regression we guard against).
+    with start_server() as server:
+        with make_stream() as stream:
+            server.for_path('/', stream)
+            stream.push("event: a\ndata: data1\n\n")
+            client = SSEClient(
+                connect=ConnectStrategy.http(server.uri),
+                error_strategy=ErrorStrategy.always_continue(),
+                initial_retry_delay=0,
+            )
+            try:
+                client.start()
+                event1 = next(client.events)
+                assert event1.data == 'data1'
+
+                reader_woke = threading.Event()
+
+                def reader():
+                    try:
+                        next(client.all)  # blocks mid-read on the idle stream
+                    except BaseException:
+                        pass
+                    finally:
+                        reader_woke.set()
+
+                reader_thread = threading.Thread(target=reader, daemon=True)
+                reader_thread.start()
+                time.sleep(0.3)  # let the reader block inside the socket read
+
+                stopped = threading.Event()
+
+                def stopper():
+                    getattr(client, stop_method_name)()
+                    stopped.set()
+
+                stopper_thread = threading.Thread(target=stopper, daemon=True)
+                stopper_thread.start()
+
+                # Must never hang, on any urllib3 version.
+                assert stopped.wait(timeout=5), \
+                    "%s() deadlocked on a concurrently blocked reader" % stop_method_name
+
+                if _CAN_WAKE_READER:
+                    # urllib3 2.x: the closer's resp.shutdown() wakes the blocked reader.
+                    assert reader_woke.wait(timeout=5), \
+                        "%s() did not wake the concurrently blocked reader" % stop_method_name
+                else:
+                    # urllib3 1.26.x: the reader is intentionally not woken (U-prime does not
+                    # touch private socket attrs); only the no-hang guarantee above applies.
+                    pass
+            finally:
+                client.close()
+
+
+def test_close_stops_without_hang_with_concurrent_reader():
+    _run_concurrent_stop_test('close')
+
+
+def test_interrupt_stops_without_hang_with_concurrent_reader():
+    _run_concurrent_stop_test('interrupt')
 
 
 def test_sse_client_allows_modifying_query_params_dynamically():

--- a/ld_eventsource/testing/test_http_connect_strategy_with_sse_client.py
+++ b/ld_eventsource/testing/test_http_connect_strategy_with_sse_client.py
@@ -2,8 +2,6 @@ import threading
 import time
 from urllib.parse import parse_qsl
 
-import urllib3.response
-
 from ld_eventsource import *
 from ld_eventsource.actions import *
 from ld_eventsource.config import *
@@ -97,18 +95,10 @@ def test_sse_client_reconnects_after_interrupt():
                     assert event2.data == 'data2'
 
 
-# urllib3 2.x exposes HTTPResponse.shutdown(), which lets the closer wake a reader that is
-# blocked mid-read before closing the connection. urllib3 1.26.x has no such built-in, and
-# under design U-prime we deliberately do not reach into private socket attributes to wake
-# the reader. So on 2.x the reader is woken; on 1.26.x it is not -- but in NEITHER case may
-# the stop call itself hang.
-_CAN_WAKE_READER = hasattr(urllib3.response.HTTPResponse, "shutdown")
-
-
 def _run_concurrent_stop_test(stop_method_name):
     # Exercises the concurrent shutdown pattern: a worker thread blocks mid-read on an idle
     # stream while another thread stops the client. The stop call must return within the
-    # timeout on every urllib3 version (a hang here is the regression we guard against).
+    # timeout (a hang here is the regression we guard against).
     with start_server() as server:
         with make_stream() as stream:
             server.for_path('/', stream)
@@ -146,18 +136,13 @@ def _run_concurrent_stop_test(stop_method_name):
                 stopper_thread = threading.Thread(target=stopper, daemon=True)
                 stopper_thread.start()
 
-                # Must never hang, on any urllib3 version.
+                # Must never hang.
                 assert stopped.wait(timeout=5), \
                     "%s() deadlocked on a concurrently blocked reader" % stop_method_name
 
-                if _CAN_WAKE_READER:
-                    # urllib3 2.x: the closer's resp.shutdown() wakes the blocked reader.
-                    assert reader_woke.wait(timeout=5), \
-                        "%s() did not wake the concurrently blocked reader" % stop_method_name
-                else:
-                    # urllib3 1.26.x: the reader is intentionally not woken (U-prime does not
-                    # touch private socket attrs); only the no-hang guarantee above applies.
-                    pass
+                # The closer's resp.shutdown() wakes the blocked reader.
+                assert reader_woke.wait(timeout=5), \
+                    "%s() did not wake the concurrently blocked reader" % stop_method_name
             finally:
                 client.close()
 

--- a/ld_eventsource/testing/test_http_connect_strategy_with_sse_client.py
+++ b/ld_eventsource/testing/test_http_connect_strategy_with_sse_client.py
@@ -1,6 +1,9 @@
+import sys
 import threading
 import time
 from urllib.parse import parse_qsl
+
+import urllib3.response
 
 from ld_eventsource import *
 from ld_eventsource.actions import *
@@ -95,6 +98,12 @@ def test_sse_client_reconnects_after_interrupt():
                     assert event2.data == 'data2'
 
 
+# resp.shutdown() (SHUT_RD) can wake a reader blocked mid-recv only on POSIX with
+# urllib3 >= 2.3 (which has HTTPResponse.shutdown()). Elsewhere the closer releases the
+# connection instead, so the reader is NOT woken -- but the stop must still never hang.
+_CAN_WAKE_READER = sys.platform != "win32" and hasattr(urllib3.response.HTTPResponse, "shutdown")
+
+
 def _run_concurrent_stop_test(stop_method_name):
     # Exercises the concurrent shutdown pattern: a worker thread blocks mid-read on an idle
     # stream while another thread stops the client. The stop call must return within the
@@ -140,9 +149,10 @@ def _run_concurrent_stop_test(stop_method_name):
                 assert stopped.wait(timeout=5), \
                     "%s() deadlocked on a concurrently blocked reader" % stop_method_name
 
-                # The closer's resp.shutdown() wakes the blocked reader.
-                assert reader_woke.wait(timeout=5), \
-                    "%s() did not wake the concurrently blocked reader" % stop_method_name
+                if _CAN_WAKE_READER:
+                    # POSIX + urllib3>=2.3: the closer's resp.shutdown() wakes the reader.
+                    assert reader_woke.wait(timeout=5), \
+                        "%s() did not wake the concurrently blocked reader" % stop_method_name
             finally:
                 client.close()
 

--- a/ld_eventsource/testing/test_sse_client_retry.py
+++ b/ld_eventsource/testing/test_sse_client_retry.py
@@ -154,6 +154,45 @@ def test_retry_delay_gets_reset_after_threshold():
         assert client.next_retry_delay == initial_delay * 2
 
 
+def test_old_connection_closed_on_fault_reconnect():
+    # When a stream ends and the client reconnects, the old connection must be closed
+    # (rather than left for garbage collection) before the new one is opened.
+    closed = []
+
+    class RespondAndTrackClose(MockConnectionHandler):
+        def __init__(self, data, index):
+            self.__data = data
+            self.__index = index
+
+        def apply(self) -> ConnectionResult:
+            index = self.__index
+            return ConnectionResult(
+                stream=iter([bytes(self.__data, 'utf-8')]),
+                closer=lambda: closed.append(index),
+            )
+
+    mock = MockConnectStrategy(
+        RespondAndTrackClose("data: data1\n\n", 0),
+        RespondAndTrackClose("data: data2\n\n", 1),
+        ExpectNoMoreRequests(),
+    )
+    with SSEClient(
+        connect=mock,
+        error_strategy=ErrorStrategy.always_continue(),
+        retry_delay_strategy=no_delay(),
+    ) as client:
+        events = client.events
+
+        event1 = next(events)
+        assert event1.data == 'data1'
+
+        # Reading data2 requires the first stream to end and the client to reconnect;
+        # the first connection must have been closed as part of that reconnect.
+        event2 = next(events)
+        assert event2.data == 'data2'
+        assert closed == [0]
+
+
 def test_can_interrupt_and_restart_stream():
     initial_delay = 0.005
     mock = MockConnectStrategy(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries",
 ]
 dependencies = [
-    "urllib3>=2.0.0,<3",
+    "urllib3>=1.26.0,<3",
 ]
 
 [project.urls]
@@ -55,7 +55,7 @@ docs = [
     "pyrfc3339>=1.0",
     "jsonpickle>1.4.1",
     "semver>=2.7.9",
-    "urllib3>=2.0.0",
+    "urllib3>=1.26.0",
     "jinja2>=3.1.2",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries",
 ]
 dependencies = [
-    "urllib3>=1.26.0,<3",
+    "urllib3>=2.0.0,<3",
 ]
 
 [project.urls]
@@ -55,7 +55,7 @@ docs = [
     "pyrfc3339>=1.0",
     "jsonpickle>1.4.1",
     "semver>=2.7.9",
-    "urllib3>=1.26.0",
+    "urllib3>=2.0.0",
     "jinja2>=3.1.2",
 ]
 


### PR DESCRIPTION
## What

Fixes a streaming socket leak on both connection-teardown paths — explicit `close()`/`interrupt()` and automatic fault-driven reconnect. Previously the socket was released to the pool (`release_conn`) or the connection reference was simply dropped, so the socket lingered until GC rather than being closed.

The core difficulty: deterministically closing the socket requires first **waking a reader that may be blocked mid-`recv()`**, and the mechanism for that is **platform- and version-specific**:

- **POSIX + urllib3 ≥ 2.3** (which added `HTTPResponse.shutdown()`): `resp.shutdown()` (`SHUT_RD`) wakes the blocked reader, then `resp.close()` tears the socket down deterministically.
- **Windows**, or **urllib3 < 2.3** (no `shutdown()`): there is no public, non-deadlocking way to wake a blocked reader (`shutdown()` doesn't interrupt `recv()` on Windows; closing the socket doesn't reliably either, and going through `resp.close()` → `_fp.close()` deadlocks on the reader's `BufferedReader` lock). So we fall back to `release_conn()` — the socket leaks until GC (the pre-existing baseline), but it **never hangs**.

So the per-connection closer is one predicate — *"can we safely wake a blocked reader?"*:

```python
if sys.platform != "win32" and hasattr(resp, "shutdown"):
    if resp.connection is not None:
        try: resp.shutdown()
        except Exception: ...
    resp.close()            # POSIX + urllib3>=2.3: deterministic close
else:
    resp.release_conn()     # Windows / old urllib3: leak, never hang
```

Also in this PR:
- The **reconnect path** (`sse_client.py` `_close_current_connection`) now routes through the closer instead of dropping the connection reference (the common-case leak).
- `_HttpClientImpl.close()` closes pooled connections before `clear()` (on urllib3 2.x, `PoolManager.clear()` alone does not FIN pooled sockets), for pools eventsource created.
- A **`floor` CI job** (`UV_RESOLUTION=lowest-direct`, Linux + Windows, one Python) guards the minimum declared dependency versions — the regular jobs only run against the locked/latest versions, which is why the urllib3-1.26/2.0–2.2 deadlock corner would otherwise ship untested.

## Why

Fixes the FDv1 streaming socket leak (**SDK-2668**). Net effect vs. the baseline leak: **POSIX (urllib3 ≥ 2.3) is now deterministic** on interrupt/reconnect/close; **Windows and older urllib3 are equal to the baseline** (leak, never hang). No breaking dependency change.

## urllib3 support

Keeps `urllib3 >= 1.26` (no floor bump). urllib3 without `HTTPResponse.shutdown()` (1.26, 2.0–2.2) transparently takes the `release_conn` fallback — the same path Windows takes — so those versions leak-but-never-hang rather than deadlocking.

## Upstream

The Windows/old-urllib3 leak is only fully fixable upstream: `HTTPResponse.shutdown()` (added in [urllib3#3527](https://github.com/urllib3/urllib3/pull/3527) for [urllib3#2868](https://github.com/urllib3/urllib3/issues/2868)) is POSIX-only. A follow-up urllib3 issue tracks making it platform-correct; when that lands, the fallback can be dropped and Windows becomes deterministic too.

## Validation

- Full Linux + Windows CI matrix green, plus both `floor` (lowest-direct) jobs — including urllib3 1.26 on Windows (both fallback conditions at once).
- Local cross-version: urllib3 1.26.20 / 2.2.3 (the last version that *deadlocked* before this gate) / 2.3.0 / 2.7.0 all pass.
- Concurrent-stop tests assert no hang on all platforms/versions, and reader-wakeup only where `shutdown()` is available (`_CAN_WAKE_READER`).